### PR TITLE
Fix for Search to work on v18

### DIFF
--- a/plugin.video.masteraniredux/resources/lib/indexers/animeshows.py
+++ b/plugin.video.masteraniredux/resources/lib/indexers/animeshows.py
@@ -187,10 +187,6 @@ class Indexer:
 
         if self.query is None or self.query is '': return
 
-        if query is None:
-            control.execute("Container.Update(%s?action=search&query=%s, false)" % (sys.argv[0], self.query))
-            return
-
         result = client.request("http://www.masterani.me/api/anime/search?search=%s&sb=true" % self.query)
         result = json.loads(result)
 


### PR DESCRIPTION
There was an issue in my previous version where Search was not working on Kodi 18; a user commented that Container.Update is obsolete in v18 and not really used in v17. Removing these lines doesn't affect v17, but enables Search to work on v18.